### PR TITLE
Check if running as root before listing configs

### DIFF
--- a/src/code/configs.py
+++ b/src/code/configs.py
@@ -154,6 +154,10 @@ def iterate_configs(source: Optional[str]) -> Iterator[Config]:
                 "Config directory does not exist. Use 'create-config' command to create a config."
             )
             return
+
+        if not os.access(_CONFIG_PATH, os.R_OK):
+            os_utils.eprint(f"Cannot access snapshots; run as root?")
+            return
         config_iterator = (str(path) for path in _CONFIG_PATH.iterdir())
 
     # Check whether the necessary fields in the configuration file are filled in

--- a/src/code/main.py
+++ b/src/code/main.py
@@ -17,6 +17,7 @@ import collections
 import datetime
 import itertools
 import logging
+import os
 
 from . import batch_deleter
 from . import colored_logs
@@ -226,6 +227,10 @@ def _config_operation(
 
     # Which mount paths to sync.
     to_sync: list[configs.Config] = []
+
+    if os.geteuid() != 0:
+        os_utils.eprint(f"Cannot list configs; run as root?")
+        return
 
     # Commands that need to access existing config.
     for config in configs.iterate_configs(source=source):

--- a/src/code/main.py
+++ b/src/code/main.py
@@ -17,7 +17,6 @@ import collections
 import datetime
 import itertools
 import logging
-import os
 
 from . import batch_deleter
 from . import colored_logs
@@ -227,10 +226,6 @@ def _config_operation(
 
     # Which mount paths to sync.
     to_sync: list[configs.Config] = []
-
-    if os.geteuid() != 0:
-        os_utils.eprint(f"Cannot list configs; run as root?")
-        return
 
     # Commands that need to access existing config.
     for config in configs.iterate_configs(source=source):

--- a/src/code/snap_operator.py
+++ b/src/code/snap_operator.py
@@ -31,6 +31,11 @@ from typing import Any, Iterator, Optional, TypeVar
 def _get_existing_snaps(config: configs.Config) -> Iterator[snap_holder.Snapshot]:
     """Returns existing backups in chronological order."""
     destdir = os.path.dirname(config.dest_prefix)
+
+    if not os.access(destdir, os.R_OK):
+        os_utils.eprint(f"Cannot access snapshots; run as root?")
+        return
+
     for fname in os.listdir(destdir):
         pathname = os.path.join(destdir, fname)
         if not os.path.isdir(pathname):


### PR DESCRIPTION
If the snapshot directory has permissions like 700, then yabsnap cannot access it without root privileges. My solution probably isn't the best but it works for me